### PR TITLE
ci: remove `|| true` from lint and test commands in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,14 @@ jobs:
       - name: Lint (frontend)
         run: |
           cd frontend
-          npm run lint || true
+          npm run lint
       - name: Test (frontend)
         run: |
           cd frontend
-          npm test -- --watchAll=false || true
+          npm test -- --watchAll=false
+      - name: Create .env for backend
+        run: |
+          echo "MONGODB_URI=${{ secrets.MONGODB_URI }}" > backend/.env
       - name: Install dependencies (backend)
         run: |
           cd backend
@@ -35,8 +38,8 @@ jobs:
       - name: Lint (backend)
         run: |
           cd backend
-          npm run lint || true
+          npm run lint
       - name: Test (backend)
         run: |
           cd backend
-          npm test || true
+          npm test


### PR DESCRIPTION
The `|| true` was previously used to prevent the CI pipeline from failing on linting or test errors. This was masking potential issues in the codebase. Removing it ensures that the pipeline fails if linting or tests fail, enforcing better code quality and reliability. Additionally, added a step to create a `.env` file for the backend using the MONGODB_URI secret.